### PR TITLE
Initial Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,63 @@
+language: cpp
+dist: focal
+os: linux
+compiler: clang
+
+
+jobs:
+  fast_finish: true
+  include:
+    - name: "Ubuntu Focal Fossa 20.04, Clang"
+      os: linux
+      dist: focal
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - cmake
+            - ninja-build
+            - libasound2-dev
+            - libxrandr-dev
+            - libxinerama-dev
+            - libxcursor-dev
+      env: 
+        - MATRIX_EVAL="CC=clang && CXX=clang++ && BUILD_TYPE=Release"
+        - CMAKE_ROOT_PATH="/usr/bin/"
+        - BUILD_SYSTEM="-GNinja"
+        
+        
+    - name: "MacOS, Clang"
+      os: osx
+      compiler: clang
+      env: 
+        - MATRIX_EVAL="CC=clang && CXX=clang++ && BUILD_TYPE=Release"
+        - BUILD_SYSTEM="-GNinja"
+      before_install: brew install ninja
+        
+        
+    - name: "Windows"
+      os: windows
+      compiler: clang
+      env: 
+        - MATRIX_EVAL="CC=clang && CXX=clang++ && BUILD_TYPE=Release"
+      before_install: choco install ninja
+
+
+before_install:
+  - eval "${MATRIX_EVAL}"
+
+
+before_script:
+  - mkdir build
+  - cd build
+  - ${CMAKE_ROOT_PATH}cmake --version
+  - ${CXX} --version
+  - ${CC} --version
+  - ${CMAKE_ROOT_PATH}cmake ${BUILD_SYSTEM} -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_C_COMPILER=${CC} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
+
+
+script:
+  - ${CMAKE_ROOT_PATH}cmake --build .
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Eq
+[![Build Status](https://travis-ci.com/witte/Eq.svg?branch=master)](https://travis-ci.com/witte/Eq)
 <div align="center"><img src="Screenshot.png"/></div>
-
 An equalizer plugin made with the Juce framework. My attempt at writing a simple but fully functional audio plugin, customizing Juce's LookAndFeel class and the behavior of some components. Work In Progress.
 <br>
 <br>


### PR DESCRIPTION
Builds the plugin on Linux, Mac and Windows. Two issues:
- needs a workaround to get a more recent CMake (Juce needs at least 3.15) to work on Ubuntu
- Ninja build system doesn't work on Windows